### PR TITLE
Mute 3rd-party logs

### DIFF
--- a/pushapkscript/script.py
+++ b/pushapkscript/script.py
@@ -76,6 +76,7 @@ def main(name=None, config_path=None):
 
     logging.basicConfig(**craft_logging_config(context))
     logging.getLogger('taskcluster').setLevel(logging.WARNING)
+    logging.getLogger('oauth2client').setLevel(logging.WARNING)
 
     loop = asyncio.get_event_loop()
     with aiohttp.ClientSession() as session:


### PR DESCRIPTION
Follow up of mozilla-releng/mozapkpublisher#4. As we import `push_apk.py` as a library, logging rules should be applied in pushapkscript too. r? @catlee 