### PR TITLE
Upgrade pushapkscript to use scriptworker v1.0.0b4 (without chain of trust enabled)

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -1,6 +1,6 @@
 {
     "work_dir": "/absolute/path/to/work_dir",
-    "schema_file": "pushapkscript/data/pushapk_task_schema.json",
+    "schema_file": "/project/path/to/pushapkscript/pushapkscript/data/pushapk_task_schema.json",
 
     "google_play_accounts": {
         "aurora": {
@@ -25,8 +25,5 @@
         "release": "release"
     },
 
-    "valid_artifact_schemes": ["https"],
-    "valid_artifact_netlocs": ["queue.taskcluster.net"],
-    "valid_artifact_path_regexes": ["/v1/task/(?P<taskId>[^/]+)(/runs/\\d+)?/artifacts/(?P<filepath>.*)$"],
     "verbose": true
 }

--- a/pushapkscript/script.py
+++ b/pushapkscript/script.py
@@ -50,9 +50,12 @@ def get_default_config():
     default_config = {
         'work_dir': os.path.join(parent_dir, 'work_dir'),
         'schema_file': os.path.join(cwd, 'pushapkscript', 'data', 'pushapk_task_schema.json'),
-        'valid_artifact_schemes': ['https'],
-        'valid_artifact_netlocs': ['queue.taskcluster.net'],
-        'valid_artifact_path_regexes': [r'''/v1/task/(?P<taskId>[^/]+)(/runs/\d+)?/artifacts/(?P<filepath>.*)$'''],
+        # TODO Delete this key once Chain Of Trust is enabled
+        'valid_artifact_rules': [{
+          'netlocs': ['queue.taskcluster.net'],
+          'path_regexes': ['^/v1/task/(?P<taskId>[^/]+)(/runs/\\d+)?/artifacts/(?P<filepath>.*)$'],
+          'schemes': ['https']
+        }],
         'verbose': False,
     }
     return default_config

--- a/pushapkscript/test/test_script.py
+++ b/pushapkscript/test/test_script.py
@@ -1,9 +1,9 @@
 import logging
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from pushapkscript.script import craft_logging_config
+from pushapkscript.script import craft_logging_config, get_default_config
 
 
 class ScriptTest(unittest.TestCase):
@@ -20,4 +20,19 @@ class ScriptTest(unittest.TestCase):
         self.assertEqual(craft_logging_config(context), {
             'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
             'level': logging.INFO
+        })
+
+    @patch('os.getcwd')
+    def test_get_default_config(self, current_working_dir_patch):
+        current_working_dir_patch.return_value = '/a/current/dir'
+
+        self.assertEqual(get_default_config(), {
+            'work_dir': '/a/current/work_dir',
+            'schema_file': '/a/current/dir/pushapkscript/data/pushapk_task_schema.json',
+            'valid_artifact_rules': [{
+              'netlocs': ['queue.taskcluster.net'],
+              'path_regexes': ['^/v1/task/(?P<taskId>[^/]+)(/runs/\\d+)?/artifacts/(?P<filepath>.*)$'],
+              'schemes': ['https']
+            }],
+            'verbose': False,
         })

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 google-api-python-client==1.5.3
-mozapkpublisher==0.1.3
+mozapkpublisher==0.1.4
 oauth2client==3.0.0
 pyOpenSSL==16.1.0
-scriptworker==0.7.2
+scriptworker==1.0.0b4
 taskcluster==0.3.4


### PR DESCRIPTION
Basically, the only change needed was related `valid_artifact_rules`. I plan to hard code it until Chain of Trust is enabled. Once it is, artifacts will be downloaded directly via scripworker, so pushapkscript won't have to know about this anymore. Because the config file has to be changed, v0.2.0 should be released (at any point) after this patch.

This also upgrades mozapkpublisher (enables better logging and uses new versions of store_l10n cc @flodolo ). 

This has been tested locally as far as I could get: APKs are refused by Google Play because we don't have more recent APK to provide (except the single locale ones, but [that check stops](https://github.com/mozilla-releng/mozapkpublisher/pull/5) the publishing at an earlier step). 