### PR TITLE
Upgrade pyOpenSSL to get support for OpenSSL v1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 google-api-python-client==1.5.3
 mozapkpublisher==0.1.4
 oauth2client==3.0.0
-pyOpenSSL==16.1.0
+pyOpenSSL==16.2.0
 scriptworker==1.0.0b4
 taskcluster==0.3.4


### PR DESCRIPTION
See https://github.com/mozilla-releng/mozapkpublisher/pull/13

New dependency tested at: https://tools.taskcluster.net/task-inspector/#a2vBrUSySxqgvPlC4G8S5Q/0