### PR TITLE
Verify APK has a signature with SHA-1 digest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: false
+sudo: required
 
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 install:
     - travis_retry pip install tox
 script:
-    - jdk_switcher use openjdk8
+    - jdk_switcher use openjdk7
     - tox -e py35
 after_success:
     - tox -e py35-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
 install:
     - travis_retry pip install tox
 script:
-    - jdk_switcher use openjdk8
     - java -version
     - tox -e py35
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ addons:
   apt:
     packages:
       - openjdk-7-jdk
-      - openjdk-7-jdk-set-default
 
 install:
     - travis_retry pip install tox
+    - jdk_switcher use openjdk7
 script:
     - java -version
     - tox -e py35

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
     - travis_retry pip install tox
 script:
     - jdk_switcher use openjdk7
+    - java -version
     - tox -e py35
 after_success:
     - tox -e py35-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 addons:
   apt:
     packages:
-      - openjdk-7-jdk
+      - openjdk-8-jdk
 
 install:
     - travis_retry pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ python:
 env:
   - SKIP_NETWORK_TESTS=0
 
+addons:
+  apt:
+    packages:
+      - openjdk-7-jdk
+
 install:
     - travis_retry pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 addons:
   apt:
     packages:
-      - openjdk-8-jdk
+      - oracle-java8-installer
 
 env:
   - SKIP_NETWORK_TESTS=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.5"
 
 jdk:
-  - openjdk7
+  - oraclejdk8
 
 env:
   - SKIP_NETWORK_TESTS=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 addons:
   apt:
     packages:
-      - openjdk-7-jdk
+      - openjdk-8-jdk
 
 env:
   - SKIP_NETWORK_TESTS=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ install:
     - travis_retry pip install tox
 script:
     - jdk_switcher use openjdk8
-    - jarsigner -help
-    - dpkg -S jarsigner
     - tox -e py35
 after_success:
     - tox -e py35-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
 addons:
   apt:
     packages:
-      - openjdk-8-jdk
+      - openjdk-7-jdk
+      - openjdk-7-jdk-set-default
 
 install:
     - travis_retry pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: false
+
 language: python
 python:
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,13 @@ language: python
 python:
   - "3.5"
 
-addons:
-  apt:
-    packages:
-      - oracle-java8-installer
-
 env:
   - SKIP_NETWORK_TESTS=0
 
 install:
     - travis_retry pip install tox
 script:
+    - jdk_switcher use oraclejdk8
     - tox -e py35
 after_success:
     - tox -e py35-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python:
   - "3.5"
 
+jdk:
+  - openjdk7
+
 env:
   - SKIP_NETWORK_TESTS=0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,3 @@ script:
     - tox -e py35
 after_success:
     - tox -e py35-coveralls
-
-# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 install:
     - travis_retry pip install tox
 script:
-    - jdk_switcher use oraclejdk8
+    - jdk_switcher use openjdk8
     - tox -e py35
 after_success:
     - tox -e py35-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 install:
     - travis_retry pip install tox
 script:
+    - jdk_switcher use openjdk8
     - java -version
     - tox -e py35
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
 install:
     - travis_retry pip install tox
 script:
-    - jdk_switcher use openjdk7
     - java -version
     - tox -e py35
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: python
 python:
   - "3.5"
 
-jdk:
-  - oraclejdk8
+addons:
+  apt:
+    packages:
+      - openjdk-7-jdk
 
 env:
   - SKIP_NETWORK_TESTS=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ install:
     - travis_retry pip install tox
 script:
     - jdk_switcher use openjdk8
+    - jarsigner -help
+    - dpkg -S jarsigner
     - tox -e py35
 after_success:
     - tox -e py35-coveralls

--- a/pushapkscript/jarsigner.py
+++ b/pushapkscript/jarsigner.py
@@ -1,9 +1,12 @@
 import logging
+import re
 import subprocess
 
 from pushapkscript.exceptions import SignatureError
 
 log = logging.getLogger(__name__)
+
+DIGEST_ALGORITHM_REGEX = re.compile(r'\s*Digest algorithm: (\S+)$', re.MULTILINE)
 
 
 def verify(context, apk_path, channel):
@@ -12,16 +15,38 @@ def verify(context, apk_path, channel):
 
     completed_process = subprocess.run([
         binary_path, '-verify', '-strict',
+        '-verbose',     # Needed to check the digest algorithm
         '-keystore', keystore_path,
         apk_path,
         certificate_alias
     ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
 
-    if completed_process.returncode != 0:
-        log.critical(completed_process.stdout)
+    command_output = completed_process.stdout
+    _check_certificate_via_return_code(completed_process.returncode, command_output, binary_path, apk_path, certificate_alias, keystore_path)
+    _check_digest_algorithm(command_output)
+
+
+def _check_certificate_via_return_code(return_code, command_output, binary_path, apk_path, certificate_alias, keystore_path):
+    if return_code != 0:
+        log.critical(command_output)
         raise SignatureError(
             '{} doesn\'t verify apk "{}". It compared certificate against "{}", located in keystore "{}"'
             .format(binary_path, apk_path, certificate_alias, keystore_path)
+        )
+
+
+def _check_digest_algorithm(command_output):
+    # This prevents https://bugzilla.mozilla.org/show_bug.cgi?id=1332916
+    match_result = DIGEST_ALGORITHM_REGEX.search(command_output)
+    if match_result is None:
+        log.critical(command_output)
+        raise SignatureError('Could not find what digest algorithm was used to sign this APK')
+
+    digest_algorithm = match_result.group(1)
+    if digest_algorithm != 'SHA1':
+        log.critical(command_output)
+        raise SignatureError(
+            'Wrong digest algorithm: SHA1 digest is expected, but "{}" was found'.format(digest_algorithm)
         )
 
 

--- a/pushapkscript/test/integration/test_integration_script.py
+++ b/pushapkscript/test/integration/test_integration_script.py
@@ -48,7 +48,6 @@ class ConfigFileGenerator(object):
             "schema_file": "{project_data_dir}/pushapk_task_schema.json",
             "verbose": true,
 
-            "jarsigner_binary": "/usr/lib/jvm/java-8-openjdk-amd64/bin/jarsigner",
             "jarsigner_key_store": "{keystore_path}",
             "jarsigner_certificate_alias": "{certificate_alias}",
             "google_play_accounts": {{

--- a/pushapkscript/test/integration/test_integration_script.py
+++ b/pushapkscript/test/integration/test_integration_script.py
@@ -48,6 +48,7 @@ class ConfigFileGenerator(object):
             "schema_file": "{project_data_dir}/pushapk_task_schema.json",
             "verbose": true,
 
+            "jarsigner_binary": "/usr/lib/jvm/java-8-openjdk-amd64/bin/jarsigner",
             "jarsigner_key_store": "{keystore_path}",
             "jarsigner_certificate_alias": "{certificate_alias}",
             "google_play_accounts": {{

--- a/pushapkscript/test/test_jarsigner.py
+++ b/pushapkscript/test/test_jarsigner.py
@@ -31,26 +31,49 @@ class JarSignerTest(unittest.TestCase):
             with patch('subprocess.run') as run:
                 run.return_value = MagicMock()
                 run.return_value.returncode = 0
+                run.return_value.stdout = '''
+                    smk      632 Mon Feb 01 12:54:21 CET 2016 application.ini
+                        Digest algorithm: SHA1
+                '''
                 jarsigner.verify(self.context, '/path/to/apk', channel)
 
                 run.assert_called_with([
-                    '/path/to/jarsigner', '-verify', '-strict', '-keystore', '/path/to/keystore', '/path/to/apk', alias
+                    '/path/to/jarsigner', '-verify', '-strict', '-verbose', '-keystore', '/path/to/keystore', '/path/to/apk', alias
                 ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
 
     def test_verify_should_call_executable_with_defaults_arguments(self):
         with patch('subprocess.run') as run:
             run.return_value = MagicMock()
             run.return_value.returncode = 0
+            run.return_value.stdout = 'Digest algorithm: SHA1'
             jarsigner.verify(self.minimal_context, '/path/to/apk', channel='aurora')
 
             run.assert_called_with([
-                'jarsigner', '-verify', '-strict', '-keystore', '/path/to/keystore', '/path/to/apk', 'nightly'
+                'jarsigner', '-verify', '-strict', '-verbose', '-keystore', '/path/to/keystore', '/path/to/apk', 'nightly'
             ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
 
     def test_raises_error_when_return_code_is_not_0(self):
         with patch('subprocess.run') as run:
             run.return_value = MagicMock()
             run.return_value.returncode = 1
+
+            with self.assertRaises(SignatureError):
+                jarsigner.verify(self.context, '/path/to/apk', channel='aurora')
+
+    def test_raises_error_when_digest_is_not_sha1(self):
+        with patch('subprocess.run') as run:
+            run.return_value = MagicMock()
+            run.return_value.returncode = 0
+            run.return_value.stdout = 'Digest algorithm: SHA256'
+
+            with self.assertRaises(SignatureError):
+                jarsigner.verify(self.context, '/path/to/apk', channel='aurora')
+
+    def test_raises_error_when_no_digest_algo_is_returned_by_jarsigner(self):
+        with patch('subprocess.run') as run:
+            run.return_value = MagicMock()
+            run.return_value.returncode = 0
+            run.return_value.stdout = 'Some random output'
 
             with self.assertRaises(SignatureError):
                 jarsigner.verify(self.context, '/path/to/apk', channel='aurora')


### PR DESCRIPTION
Fixes #11. 

`jarsigner -verbose` tells which algorithm was used. When tested against https://archive.mozilla.org/pub/mobile/nightly/2017/01/2017-01-27-08-41-15-mozilla-aurora-android-x86/fennec-53.0a2.multi.android-i386.apk : the output contained SHA256 (like [in this test](https://github.com/mozilla-releng/pushapkscript/pull/13/files#diff-1f50f203663a0f6bd87c4b7b2226838bR64)), whereas the expected value should remain "SHA1". 