### PR TITLE
Fix integration test with newer links

### DIFF
--- a/pushapkscript/test/helpers/task_generator.py
+++ b/pushapkscript/test/helpers/task_generator.py
@@ -5,10 +5,10 @@ import json
 class TaskGenerator(object):
     def __init__(self, apks=None):
         self.apks = apks if apks is not None else {
-            'armv7_v15': 'https://queue.taskcluster.net/v1/task/DIYnEVJ_SaSLGWtd3_n3VA/artifacts/\
-public%2Fbuild%2Ffennec-46.0a2.en-US.android-arm.apk',
-            'x86': 'https://queue.taskcluster.net/v1/task/EZJ0suL7St65V_MM0iBhKw/artifacts/\
-public%2Fbuild%2Ffennec-46.0a2.en-US.android-i386.apk'
+            'armv7_v15': 'https://queue.taskcluster.net/v1/task/WNIh4L_BTVKZhDk0KUAptQ/artifacts/\
+public/build/fennec-52.0a2.multi.android-arm.apk',
+            'x86': 'https://queue.taskcluster.net/v1/task/WFVQok4TQOmUS8F6p2VFDw/artifacts/\
+public/build/fennec-52.0a2.multi.android-i386.apk'
         }
 
     def generate_file(self, work_dir):
@@ -28,7 +28,7 @@ public%2Fbuild%2Ffennec-46.0a2.en-US.android-i386.apk'
           "created": "2015-05-08T16:15:58.903Z",
           "deadline": "2015-05-08T18:15:59.010Z",
           "expires": "2016-05-08T18:15:59.010Z",
-          "dependencies": ["DIYnEVJ_SaSLGWtd3_n3VA", "EZJ0suL7St65V_MM0iBhKw"],
+          "dependencies": ["WFVQok4TQOmUS8F6p2VFDw", "WNIh4L_BTVKZhDk0KUAptQ"],
           "scopes": ["project:releng:googleplay:aurora"],
           "payload": {{
             "apks": {apks},

--- a/pushapkscript/test/integration/test_integration_script.py
+++ b/pushapkscript/test/integration/test_integration_script.py
@@ -79,8 +79,8 @@ class MainTest(unittest.TestCase):
 
             PushAPK.assert_called_with(config={
                 'credentials': '/dummy/path/to/certificate.p12',
-                'apk_armv7_v15': '{}/work/public/build/fennec-46.0a2.en-US.android-arm.apk'.format(test_data_dir),
-                'apk_x86': '{}/work/public/build/fennec-46.0a2.en-US.android-i386.apk'.format(test_data_dir),
+                'apk_armv7_v15': '{}/work/public/build/fennec-52.0a2.multi.android-arm.apk'.format(test_data_dir),
+                'apk_x86': '{}/work/public/build/fennec-52.0a2.multi.android-i386.apk'.format(test_data_dir),
                 'package_name': 'org.mozilla.fennec_aurora',
                 'service_account': 'dummy-service-account@iam.gserviceaccount.com',
                 'track': 'alpha',

--- a/pushapkscript/test/test_task.py
+++ b/pushapkscript/test/test_task.py
@@ -77,7 +77,7 @@ class TaskTestAsync(asynctest.TestCase):
             return ['public/build/{}'.format(file_name) for file_name in file_names]
 
         download_artifacts.side_effect = convert_url_into_paths
-        path_prefix = '{}/public/build/fennec-46.0a2.en-US.android'.format(self.context.config['work_dir'])
+        path_prefix = '{}/public/build/fennec-52.0a2.multi.android'.format(self.context.config['work_dir'])
         files = await download_files(self.context)
 
         self.assertEqual(files, {


### PR DESCRIPTION
https://tools.taskcluster.net/task-inspector/#DIYnEVJ_SaSLGWtd3_n3VA/ is more than a year old, so artifact disappeared. This made the [only integration test fail](https://travis-ci.org/mozilla-releng/pushapkscript/builds/197260994)

This patch just updates the link, until #8 lands. 