### PR TITLE
Use APK architecture detection from mozapkpublisher

### DIFF
--- a/pushapkscript/apk.py
+++ b/pushapkscript/apk.py
@@ -1,8 +1,8 @@
 from zipfile import ZipFile
 
 from pushapkscript.exceptions import TaskVerificationError
-from pushapkscript.utils import filter_out_identical_values
 
+from mozapkpublisher.apk import get_apk_architecture
 
 _DIRECTORY_WITH_ARCHITECTURE_METADATA = 'lib/'     # For instance: lib/x86/ or lib/armeabi-v7a/
 _ARCHITECTURE_SUBDIRECTORY_INDEX = len(_DIRECTORY_WITH_ARCHITECTURE_METADATA.split('/')) - 1    # Removes last trailing slash
@@ -17,7 +17,7 @@ _EXPECTED_MOZAPKPUBLISHER_ARCHITECTURES_PER_CHANNEL = {
 
 def sort_and_check_apks_per_architectures(apks_paths, channel):
     apks_per_architectures = {
-        _convert_architecture_to_mozapkpublisher(_get_apk_architecture(apk_path)): apk_path
+        _convert_architecture_to_mozapkpublisher(get_apk_architecture(apk_path)): apk_path
         for apk_path in apks_paths
     }
 
@@ -28,38 +28,6 @@ def sort_and_check_apks_per_architectures(apks_paths, channel):
 
 def _convert_architecture_to_mozapkpublisher(architecture):
     return 'armv7_v15' if architecture == 'armeabi-v7a' else architecture
-
-
-def _get_apk_architecture(apk_path):
-    with ZipFile(apk_path) as apk_zip:
-        files_with_architecture_in_path = [
-            file_info.filename for file_info in apk_zip.infolist()
-            if _DIRECTORY_WITH_ARCHITECTURE_METADATA in file_info.filename
-        ]
-
-    if not files_with_architecture_in_path:
-        raise TaskVerificationError('"{}" does not contain a directory called "{}"'
-                                    .format(apk_path, _DIRECTORY_WITH_ARCHITECTURE_METADATA))
-
-    return _extract_architecture_from_paths(apk_path, files_with_architecture_in_path)
-
-
-def _extract_architecture_from_paths(apk_path, paths):
-    detected_architectures = [
-        path.split('/')[_ARCHITECTURE_SUBDIRECTORY_INDEX] for path in paths
-    ]
-    unique_architectures = filter_out_identical_values(detected_architectures)
-    non_empty_unique_architectures = [
-        architecture for architecture in unique_architectures if architecture
-    ]
-    number_of_unique_architectures = len(non_empty_unique_architectures)
-
-    if number_of_unique_architectures == 0:
-        raise TaskVerificationError('"{}" does not contain any architecture data under these paths: {}'.format(apk_path, paths))
-    elif number_of_unique_architectures > 1:
-        raise TaskVerificationError('"{}" contains too many architures: {}'.format(apk_path, unique_architectures))
-
-    return unique_architectures[0]
 
 
 def _check_architectures_are_valid(mozapkpublisher_architectures, channel):

--- a/pushapkscript/test/test_apk.py
+++ b/pushapkscript/test/test_apk.py
@@ -38,30 +38,6 @@ def test_convert_architecture_to_mozapkpublisher():
     assert _convert_architecture_to_mozapkpublisher('armeabi-v7a') == 'armv7_v15'
 
 
-def test_get_apk_architecture():
-    with TemporaryDirectory() as temp_dir:
-        assert _get_apk_architecture(_create_apk(temp_dir, 'x86')) == 'x86'
-        assert _get_apk_architecture(_create_apk(temp_dir, 'armeabi-v7a')) == 'armeabi-v7a'
-
-        with pytest.raises(TaskVerificationError):
-            _get_apk_architecture(_create_apk(temp_dir, architecture=None))
-
-
-def test_extract_architecture_from_paths():
-    assert _extract_architecture_from_paths(
-        '/path/to/apk', ['lib/armeabi-v7a/libmozglue.so', 'lib/armeabi-v7a/libplugin-container.so']
-    ) == 'armeabi-v7a'
-    assert _extract_architecture_from_paths(
-        '/path/to/apk', ['lib/x86/libmozglue.so', 'lib/x86/libplugin-container.so']
-    ) == 'x86'
-
-    with pytest.raises(TaskVerificationError):
-        _extract_architecture_from_paths('/path/to/apk', ['lib/'])
-
-    with pytest.raises(TaskVerificationError):
-        _extract_architecture_from_paths('/path/to/apk', ['lib/armeabi-v7a/libmozglue.so', 'lib/x86/libmozglue.so'])
-
-
 def test_check_architectures_are_valid():
     _check_architectures_are_valid(['x86', 'armv7_v15'], 'aurora')  # No failure expected
     _check_architectures_are_valid(['x86', 'armv7_v15'], 'beta')

--- a/pushapkscript/utils.py
+++ b/pushapkscript/utils.py
@@ -16,7 +16,3 @@ def mkdir(path):
 def load_json(path):
     with open(path, "r") as fh:
         return json.load(fh)
-
-
-def filter_out_identical_values(list_):
-    return list(set(list_))


### PR DESCRIPTION
WIP

Once https://github.com/mozilla-releng/mozapkpublisher/pull/32 lands, we can use the arch detection from there.

This PR breaks the public API.