### PR TITLE
Support artifacts signed by dep-signing

### DIFF
--- a/pushapkscript/apk.py
+++ b/pushapkscript/apk.py
@@ -12,6 +12,7 @@ _EXPECTED_MOZAPKPUBLISHER_ARCHITECTURES_PER_CHANNEL = {
     'aurora': ('armv7_v15', 'x86'),
     'beta': ('armv7_v15', 'x86'),
     'release': ('armv7_v15', 'x86'),
+    'dep': ('armv7_v15', 'x86'),
 }
 
 

--- a/pushapkscript/jarsigner.py
+++ b/pushapkscript/jarsigner.py
@@ -33,7 +33,8 @@ def _check_certificate_via_return_code(return_code, command_output, binary_path,
     if return_code != 0:
         log.critical(command_output)
         raise SignatureError(
-            '{} doesn\'t verify APK "{}". It compared certificate against "{}", located in keystore "{}"'
+            '{} doesn\'t verify APK "{}". It compared certificate against "{}", located in keystore "{}".\
+            Maybe you\'re now allowed to push such APKs on this instance?'
             .format(binary_path, apk_path, certificate_alias, keystore_path)
         )
 
@@ -64,7 +65,8 @@ def _pluck_configuration(context):
     certificate_aliases = context.config.get('jarsigner_certificate_aliases', {
         'aurora': 'nightly',
         'beta': 'nightly',
-        'release': 'release'
+        'release': 'release',
+        'dep': 'dep',
     })
     channel = extract_channel(context.task)
     return binary_path, keystore_path, certificate_aliases, channel

--- a/pushapkscript/jarsigner.py
+++ b/pushapkscript/jarsigner.py
@@ -3,14 +3,15 @@ import re
 import subprocess
 
 from pushapkscript.exceptions import SignatureError
+from pushapkscript.task import extract_channel
 
 log = logging.getLogger(__name__)
 
 DIGEST_ALGORITHM_REGEX = re.compile(r'\s*Digest algorithm: (\S+)$', re.MULTILINE)
 
 
-def verify(context, apk_path, channel):
-    binary_path, keystore_path, certificate_aliases = _pluck_configuration(context)
+def verify(context, apk_path):
+    binary_path, keystore_path, certificate_aliases, channel = _pluck_configuration(context)
     certificate_alias = certificate_aliases[channel]
 
     completed_process = subprocess.run([
@@ -65,5 +66,5 @@ def _pluck_configuration(context):
         'beta': 'nightly',
         'release': 'release'
     })
-
-    return binary_path, keystore_path, certificate_aliases
+    channel = extract_channel(context.task)
+    return binary_path, keystore_path, certificate_aliases, channel

--- a/pushapkscript/script.py
+++ b/pushapkscript/script.py
@@ -35,11 +35,12 @@ async def async_main(context):
         for artifacts_list in artifacts_per_task_id.values()
         for artifact in artifacts_list
     ]
-    channel = extract_channel(context.task)
-    apks_per_architectures = sort_and_check_apks_per_architectures(all_artifacts, channel)
+    apks_per_architectures = sort_and_check_apks_per_architectures(
+        all_artifacts, channel=extract_channel(context.task)
+    )
 
     log.info('Verifying APKs\' signatures...')
-    [jarsigner.verify(context, apk_path, channel) for apk_path in apks_per_architectures.values()]
+    [jarsigner.verify(context, apk_path) for apk_path in apks_per_architectures.values()]
 
     log.info('Pushing APKs to Google Play Store...')
     publish_to_googleplay(context, apks_per_architectures)

--- a/pushapkscript/task.py
+++ b/pushapkscript/task.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 
 GOOGLE_PLAY_SCOPE_PREFIX = 'project:releng:googleplay:'
-SUPPORTED_CHANNELS = ('aurora', 'beta', 'release')
+SUPPORTED_CHANNELS = ('aurora', 'beta', 'release', 'dep')
 
 
 def extract_channel(task):

--- a/pushapkscript/test/test_jarsigner.py
+++ b/pushapkscript/test/test_jarsigner.py
@@ -18,6 +18,7 @@ class JarSignerTest(unittest.TestCase):
                 'aurora': 'aurora_alias',
                 'beta': 'beta_alias',
                 'release': 'release_alias',
+                'dep': 'dep_alias',
             }
         }
         self.context.task = {
@@ -95,6 +96,7 @@ class JarSignerTest(unittest.TestCase):
                     'aurora': 'aurora_alias',
                     'beta': 'beta_alias',
                     'release': 'release_alias',
+                    'dep': 'dep_alias',
                 },
                 'aurora'
             )
@@ -110,6 +112,7 @@ class JarSignerTest(unittest.TestCase):
                     'aurora': 'nightly',
                     'beta': 'nightly',
                     'release': 'release',
+                    'dep': 'dep',
                 },
                 'aurora'
             )


### PR DESCRIPTION
pushapkscript won't fail anymore because of a wrong channel detected. However, Google Play will break at the first uploaded APK, because the signatures won't match.

We could modify mozapkpubisher to no request anything to Google Play. Nonetheless, that requires a new command line argument. I'd prefer to not do it now, because [bug 1385401](https://bugzilla.mozilla.org/show_bug.cgi?id=1385401) has started on the master branch of mozapkpublisher. 