### PR TITLE
Allow tasks to not have GP strings defined in upstreamArtifacts, for …

### DIFF
--- a/pushapkscript/exceptions.py
+++ b/pushapkscript/exceptions.py
@@ -10,3 +10,10 @@ class TaskVerificationError(ScriptWorkerTaskException):
 class SignatureError(ScriptWorkerTaskException):
     def __init__(self, msg):
         super().__init__(msg, exit_code=STATUSES['internal-error'])
+
+
+class NoGooglePlayStringsFound(Exception):
+    def __init__(self, expected_l10n_strings_file_name, upstream_artifacts):
+        super().__init__(
+            'Could not find "{}" in upstreamArtifacts: {}'.format(expected_l10n_strings_file_name, upstream_artifacts)
+        )

--- a/pushapkscript/script.py
+++ b/pushapkscript/script.py
@@ -15,6 +15,7 @@ from scriptworker.exceptions import ScriptWorkerTaskException
 
 from pushapkscript import jarsigner
 from pushapkscript.apk import sort_and_check_apks_per_architectures
+from pushapkscript.exceptions import NoGooglePlayStringsFound
 from pushapkscript.googleplay import publish_to_googleplay, should_commit_transaction, \
     is_allowed_to_push_to_google_play, get_google_play_strings_path
 from pushapkscript.task import validate_task_schema, extract_channel
@@ -48,10 +49,21 @@ async def async_main(context):
     [jarsigner.verify(context, apk_path) for apk_path in apks_per_architectures.values()]
 
     log.info('Finding whether Google Play strings can be updated...')
-    google_play_strings_path = get_google_play_strings_path(artifacts_per_task_id, failed_artifacts_per_task_id)
+    try:
+        google_play_strings_path = get_google_play_strings_path(artifacts_per_task_id, failed_artifacts_per_task_id)
+        let_mozapkpublisher_download_google_play_strings = False
+    except NoGooglePlayStringsFound:
+        # TODO: Remove this special catch once Firefox 59 reaches mozilla-release.
+        # It allows older trees (that don't have a task to fetch GP strings) to fetch
+        # strings in the push-apk job
+        google_play_strings_path = None
+        let_mozapkpublisher_download_google_play_strings = True
 
     log.info('Delegating publication to mozapkpublisher...')
-    publish_to_googleplay(context, apks_per_architectures, google_play_strings_path)
+    publish_to_googleplay(
+        context, apks_per_architectures, google_play_strings_path,
+        let_mozapkpublisher_download_google_play_strings
+    )
 
     log.info('Done!')
 

--- a/pushapkscript/script.py
+++ b/pushapkscript/script.py
@@ -56,6 +56,8 @@ async def async_main(context):
         # TODO: Remove this special catch once Firefox 59 reaches mozilla-release.
         # It allows older trees (that don't have a task to fetch GP strings) to fetch
         # strings in the push-apk job
+        log.warn('No Google Play string task defined in upstreamArtifacts. This is considered as a legacy task definition.\
+This behavior is deprecated and will be removed after Firefox 59 reaches mozilla-release.')
         google_play_strings_path = None
         let_mozapkpublisher_download_google_play_strings = True
 

--- a/pushapkscript/test/helpers/task_generator.py
+++ b/pushapkscript/test/helpers/task_generator.py
@@ -3,10 +3,12 @@ import json
 
 
 class TaskGenerator(object):
-    def __init__(self, google_play_track='alpha', rollout_percentage=None):
+    def __init__(self, google_play_track='alpha', rollout_percentage=None, google_play_strings_task=True):
         self.arm_task_id = 'fwk3elTDSe6FLoqg14piWg'
         self.x86_task_id = 'PKP2v4y0RdqOuLCqhevD2A'
-        self.google_play_strings_task_id = 'bgP9T6AnTpyTVsNA7M3OnA'
+        self.google_play_strings_task = google_play_strings_task
+        if self.google_play_strings_task is True:
+            self.google_play_strings_task_id = 'bgP9T6AnTpyTVsNA7M3OnA'
         self.google_play_track = google_play_track
         self.rollout_percentage = rollout_percentage
 
@@ -38,22 +40,24 @@ class TaskGenerator(object):
               "paths": ["public/build/target.apk"],
               "taskId": "{x86_task_id}",
               "taskType": "signing"
-            }}, {{
-              "paths": ["public/google_play_strings.json"],
-              "taskId": "{google_play_strings_task_id}",
-              "taskType": "fetch",
-              "optional": true
             }}],
             "google_play_track": "{google_play_track}"
           }}
         }}'''.format(
             arm_task_id=self.arm_task_id,
             x86_task_id=self.x86_task_id,
-            google_play_strings_task_id=self.google_play_strings_task_id,
             google_play_track=self.google_play_track,
         ))
 
         if self.rollout_percentage:
             json_content['payload']['rollout_percentage'] = self.rollout_percentage
+
+        if self.google_play_strings_task:
+            json_content['payload']['upstreamArtifacts'].append({
+               'paths': ['public/google_play_strings.json'],
+               'taskId': self.google_play_strings_task_id,
+               'taskType': 'fetch',
+               'optional': True,
+             })
 
         return json_content

--- a/pushapkscript/test/helpers/task_generator.py
+++ b/pushapkscript/test/helpers/task_generator.py
@@ -3,12 +3,13 @@ import json
 
 
 class TaskGenerator(object):
-    def __init__(self, google_play_track='alpha', rollout_percentage=None, google_play_strings_task=True):
+    def __init__(self, google_play_track='alpha', rollout_percentage=None, task_def_before_firefox_59=False, should_commit_transaction=False):
         self.arm_task_id = 'fwk3elTDSe6FLoqg14piWg'
         self.x86_task_id = 'PKP2v4y0RdqOuLCqhevD2A'
-        self.google_play_strings_task = google_play_strings_task
-        if self.google_play_strings_task is True:
+        self.task_def_before_firefox_59 = task_def_before_firefox_59
+        if self.task_def_before_firefox_59 is False:
             self.google_play_strings_task_id = 'bgP9T6AnTpyTVsNA7M3OnA'
+        self.should_commit_transaction = should_commit_transaction
         self.google_play_track = google_play_track
         self.rollout_percentage = rollout_percentage
 
@@ -52,12 +53,18 @@ class TaskGenerator(object):
         if self.rollout_percentage:
             json_content['payload']['rollout_percentage'] = self.rollout_percentage
 
-        if self.google_play_strings_task:
+        if self.task_def_before_firefox_59 is False:
             json_content['payload']['upstreamArtifacts'].append({
                'paths': ['public/google_play_strings.json'],
                'taskId': self.google_play_strings_task_id,
                'taskType': 'fetch',
                'optional': True,
              })
+
+        if self.should_commit_transaction:
+            if self.task_def_before_firefox_59:
+                json_content['payload']['dry_run'] = False
+            else:
+                json_content['payload']['commit'] = True
 
         return json_content

--- a/pushapkscript/test/integration/test_integration_script.py
+++ b/pushapkscript/test/integration/test_integration_script.py
@@ -133,8 +133,8 @@ class MainTest(unittest.TestCase):
         })
 
     @unittest.mock.patch('mozapkpublisher.push_apk.PushAPK')
-    def test_main_allows_google_play_strings_file(self, PushAPK):
-        task_generator = TaskGenerator()
+    def test_main_allows_google_play_strings_file_and_commit_transaction(self, PushAPK):
+        task_generator = TaskGenerator(should_commit_transaction=True)
         task_generator.generate_file(self.config_generator.work_dir)
 
         self._copy_all_apks_to_test_temp_dir(task_generator)
@@ -149,7 +149,7 @@ class MainTest(unittest.TestCase):
             'apk_armv7_v15': '{}/work/cot/{}/public/build/target.apk'.format(self.test_temp_dir, task_generator.arm_task_id),
             'apk_x86': '{}/work/cot/{}/public/build/target.apk'.format(self.test_temp_dir, task_generator.x86_task_id),
             'credentials': '/dummy/path/to/certificate.p12',
-            'commit': False,
+            'commit': True,
             'package_name': 'org.mozilla.fennec_aurora',
             'service_account': 'dummy-service-account@iam.gserviceaccount.com',
             'track': 'alpha',
@@ -159,8 +159,8 @@ class MainTest(unittest.TestCase):
         })
 
     @unittest.mock.patch('mozapkpublisher.push_apk.PushAPK')
-    def test_main_still_supports_task_def_without_google_play_strings_task(self, PushAPK):
-        task_generator = TaskGenerator(google_play_strings_task=False)
+    def test_main_still_supports_old_task_def(self, PushAPK):
+        task_generator = TaskGenerator(task_def_before_firefox_59=True, should_commit_transaction=True)
         task_generator.generate_file(self.config_generator.work_dir)
 
         self._copy_all_apks_to_test_temp_dir(task_generator)
@@ -170,7 +170,7 @@ class MainTest(unittest.TestCase):
             'apk_armv7_v15': '{}/work/cot/{}/public/build/target.apk'.format(self.test_temp_dir, task_generator.arm_task_id),
             'apk_x86': '{}/work/cot/{}/public/build/target.apk'.format(self.test_temp_dir, task_generator.x86_task_id),
             'credentials': '/dummy/path/to/certificate.p12',
-            'commit': False,
+            'commit': True,
             'package_name': 'org.mozilla.fennec_aurora',
             'service_account': 'dummy-service-account@iam.gserviceaccount.com',
             'track': 'alpha',

--- a/pushapkscript/test/integration/test_integration_script.py
+++ b/pushapkscript/test/integration/test_integration_script.py
@@ -157,3 +157,22 @@ class MainTest(unittest.TestCase):
                 self.test_temp_dir, task_generator.google_play_strings_task_id
             ),
         })
+
+    @unittest.mock.patch('mozapkpublisher.push_apk.PushAPK')
+    def test_main_still_supports_task_def_without_google_play_strings_task(self, PushAPK):
+        task_generator = TaskGenerator(google_play_strings_task=False)
+        task_generator.generate_file(self.config_generator.work_dir)
+
+        self._copy_all_apks_to_test_temp_dir(task_generator)
+        main(config_path=self.config_generator.generate(), close_loop=False)
+
+        PushAPK.assert_called_with(config={
+            'apk_armv7_v15': '{}/work/cot/{}/public/build/target.apk'.format(self.test_temp_dir, task_generator.arm_task_id),
+            'apk_x86': '{}/work/cot/{}/public/build/target.apk'.format(self.test_temp_dir, task_generator.x86_task_id),
+            'credentials': '/dummy/path/to/certificate.p12',
+            'commit': False,
+            'package_name': 'org.mozilla.fennec_aurora',
+            'service_account': 'dummy-service-account@iam.gserviceaccount.com',
+            'track': 'alpha',
+            'update_gp_strings_from_l10n_store': True,
+        })

--- a/pushapkscript/test/test_googleplay.py
+++ b/pushapkscript/test/test_googleplay.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from pushapkscript.exceptions import TaskVerificationError
+from pushapkscript.exceptions import TaskVerificationError, NoGooglePlayStringsFound
 from pushapkscript.googleplay import craft_push_apk_config, get_package_name, get_service_account, get_certificate_path, \
     _get_play_config, should_commit_transaction, get_google_play_strings_path, \
     _check_google_play_string_is_the_only_failed_task, _find_unique_google_play_strings_file_in_dict
@@ -193,7 +193,7 @@ class GooglePlayTest(unittest.TestCase):
             '/path/to/public/google_play_strings.json'
         )
 
-        with self.assertRaises(TaskVerificationError):
+        with self.assertRaises(NoGooglePlayStringsFound):
             _find_unique_google_play_strings_file_in_dict({
                 'apkTaskId': ['public/chainOfTrust.json.asc', '/path/to/public/build/target.apk'],
                 'someTaskId': ['public/chainOfTrust.json.asc'],


### PR DESCRIPTION
…older trees

Follow up of #26. I realized #26 will break existing task definitions. I added this temporary special case.