### PR TITLE
Allow arbitrary Google Play track names.

### DIFF
--- a/pushapkscript/data/pushapk_task_schema.json
+++ b/pushapkscript/data/pushapk_task_schema.json
@@ -51,7 +51,7 @@
                     "uniqueItems": true
                 },
                 "google_play_track": {
-                  "enum": ["production", "beta", "alpha", "rollout", "internal"]
+                  "type": "string"
                 },
                 "rollout_percentage": {
                   "type": "integer",


### PR DESCRIPTION
Google Play allows creating custom tracks now. mozapkpublisher will take
care of actually validating the value.