### PR TITLE
Removes stray comma from example task json

### DIFF
--- a/examples/task.example.json
+++ b/examples/task.example.json
@@ -39,7 +39,7 @@
       }
     ],
     "google_play_track": "beta",
-    "commit": false,
+    "commit": false
   },
   "metadata": {
     "owner": "nobody@mozilla.org",


### PR DESCRIPTION
After following the readme instructions, running `pushapkscript` the first time would fail due to invalid JSON:

```
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 43 column 3 (char 1127)
```