### PR TITLE
Fix deprecation warnings

### DIFF
--- a/pushapkscript/googleplay.py
+++ b/pushapkscript/googleplay.py
@@ -81,7 +81,7 @@ def should_commit_transaction(context):
 def get_google_play_strings_path(artifacts_per_task_id, failed_artifacts_per_task_id):
     if failed_artifacts_per_task_id:
         _check_google_play_string_is_the_only_failed_task(failed_artifacts_per_task_id)
-        log.warn("Google Play strings not found. Listings and what's new section won't be updated")
+        log.warning("Google Play strings not found. Listings and what's new section won't be updated")
         return None
 
     path = _find_unique_google_play_strings_file_in_dict(artifacts_per_task_id)

--- a/pushapkscript/script.py
+++ b/pushapkscript/script.py
@@ -32,7 +32,7 @@ async def async_main(context):
         manifest.verify(context, apk_path)
 
     if task.extract_android_product_from_scopes(context) == 'focus':
-        log.warn('Focus does not upload strings automatically. Skipping Google Play strings search.')
+        log.warning('Focus does not upload strings automatically. Skipping Google Play strings search.')
         google_play_strings_path = None
     else:
         log.info('Finding whether Google Play strings can be updated...')
@@ -51,12 +51,12 @@ async def async_main(context):
 def _log_warning_forewords(context):
     if googleplay.is_allowed_to_push_to_google_play(context):
         if googleplay.should_commit_transaction(context):
-            log.warn('You will publish APKs to Google Play. This action is irreversible,\
+            log.warning('You will publish APKs to Google Play. This action is irreversible,\
 if no error is detected either by this script or by Google Play.')
         else:
-            log.warn('APKs will be submitted to Google Play, but no change will not be committed.')
+            log.warning('APKs will be submitted to Google Play, but no change will not be committed.')
     else:
-        log.warn('You do not have the rights to reach Google Play. *All* requests will be mocked.')
+        log.warning('You do not have the rights to reach Google Play. *All* requests will be mocked.')
 
 
 def get_default_config():


### PR DESCRIPTION
Remaining warnings come from dependencies. 

```
====================================================================================== warnings summary ======================================================================================
/home/jlorenzo/git/mozilla-releng/pushapkscript/.tox/py37/lib/python3.7/site-packages/frozendict/__init__.py:16: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  class frozendict(collections.Mapping):

/home/jlorenzo/git/mozilla-releng/pushapkscript/.tox/py37/lib/python3.7/site-packages/aiohttp/multipart.py:8: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import Mapping, Sequence, deque

/home/jlorenzo/git/mozilla-releng/pushapkscript/.tox/py37/lib/python3.7/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import MutableMapping, Sequence  # noqa

-- Docs: https://docs.pytest.org/en/latest/warnings.html

```