### PR TITLE
Improves product extraction from scopes to ignore chunks on end of scope

### DIFF
--- a/pushapkscript/task.py
+++ b/pushapkscript/task.py
@@ -17,6 +17,6 @@ def extract_android_product_from_scopes(context):
         too_many_item_error_message='More than one valid scope given',
     )
 
-    android_product = scope[len(prefix):]
+    android_product = scope.split(':')[prefix.count(':')]  # the chunk after the prefix is the product name
 
     return android_product

--- a/pushapkscript/test/test_task.py
+++ b/pushapkscript/test/test_task.py
@@ -115,6 +115,10 @@ class TaskTest(unittest.TestCase):
             'prefix': 'project:mobile:focus:googleplay:product:',
             'task': {'scopes': ['project:mobile:focus:googleplay:product:focus']},
             'expected': 'focus',
+        }, {
+            'prefix': 'project:mobile:reference-browser:googleplay:product:',
+            'task': {'scopes': ['project:mobile:reference-browser:googleplay:product:reference-browser:dep']},
+            'expected': 'reference-browser',
         })
 
         for item in data:


### PR DESCRIPTION
This ensures that we properly extract "reference-browser" from the scope `project:mobile:focus:releng:googleplay:product:reference-browser:dep`