### PR TITLE
Removes "/" from os.path.join

### DIFF
--- a/pushapkscript/script.py
+++ b/pushapkscript/script.py
@@ -65,7 +65,7 @@ def get_default_config():
 
     return {
         'work_dir': os.path.join(parent_dir, 'work_dir'),
-        'schema_file': os.path.join(os.path.dirname(__file__), 'data/pushapk_task_schema.json'),
+        'schema_file': os.path.join(os.path.dirname(__file__), 'data', 'pushapk_task_schema.json'),
         'verbose': False,
     }
 


### PR DESCRIPTION
Having "/" in `os.path.join` has the wrong effect on Windows. Instead, let Python join the different directories together in the OS-specific way.

I'm too used to/spoiled by Node's `path.resolve(...)` :stuck_out_tongue: 