### PR TITLE
Fixes #71: adds do_not_contact_google_play to config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.12.0]
+## [upcoming]
+### Added
+* `do_not_contact_google_play` to instance config file
+
+## [0.12.0] - 2019-01-09
 
 ### Added
 * Support pushing [`fenix`](https://github.com/mozilla-mobile/fenix) to Google Play 

--- a/examples/config.example.json
+++ b/examples/config.example.json
@@ -26,5 +26,6 @@
 
     "taskcluster_scope_prefixes": ["project:releng:googleplay:"],
 
+    "do_not_contact_google_play": true,
     "verbose": true
 }

--- a/pushapkscript/googleplay.py
+++ b/pushapkscript/googleplay.py
@@ -7,7 +7,6 @@ from pushapkscript.task import extract_android_product_from_scopes
 
 log = logging.getLogger(__name__)
 
-_AUTHORIZED_PRODUCTS_TO_REACH_GOOGLE_PLAY = ('aurora', 'beta', 'release', 'fenix', 'focus', 'reference-browser')
 _EXPECTED_L10N_STRINGS_FILE_NAME = 'public/google_play_strings.json'
 
 
@@ -34,9 +33,8 @@ def craft_push_apk_config(context, apks, google_play_strings_path=None):
     if payload.get('rollout_percentage'):
         push_apk_config['rollout_percentage'] = payload['rollout_percentage']
 
-    # Only known android_products are allowed to connect to Google Play
-    # and only if the configuration of the pushapkscript instance allows it
-    if not is_allowed_to_push_to_google_play(context) or context.config.get('do_not_contact_google_play'):
+    # Only allowed to connect to Google Play if the configuration of the pushapkscript instance allows it
+    if context.config.get('do_not_contact_google_play'):
         push_apk_config['do_not_contact_google_play'] = True
 
     if google_play_strings_path is None:
@@ -66,11 +64,6 @@ def _get_play_config(context, android_product):
     except KeyError:
         raise TaskVerificationError('Android "{}" does not exist in the configuration of this instance.\
     Are you sure you allowed to push such APK?'.format(android_product))
-
-
-def is_allowed_to_push_to_google_play(context):
-    android_product = extract_android_product_from_scopes(context)
-    return android_product in _AUTHORIZED_PRODUCTS_TO_REACH_GOOGLE_PLAY
 
 
 def should_commit_transaction(context):

--- a/pushapkscript/googleplay.py
+++ b/pushapkscript/googleplay.py
@@ -35,7 +35,8 @@ def craft_push_apk_config(context, apks, google_play_strings_path=None):
         push_apk_config['rollout_percentage'] = payload['rollout_percentage']
 
     # Only known android_products are allowed to connect to Google Play
-    if not is_allowed_to_push_to_google_play(context):
+    # and only if the configuration of the pushapkscript instance allows it
+    if not is_allowed_to_push_to_google_play(context) or context.config.get('do_not_contact_google_play'):
         push_apk_config['do_not_contact_google_play'] = True
 
     if google_play_strings_path is None:

--- a/pushapkscript/script.py
+++ b/pushapkscript/script.py
@@ -49,14 +49,14 @@ async def async_main(context):
 
 
 def _log_warning_forewords(context):
-    if googleplay.is_allowed_to_push_to_google_play(context):
+    if not context.config.get('do_not_contact_google_play'):
         if googleplay.should_commit_transaction(context):
             log.warning('You will publish APKs to Google Play. This action is irreversible,\
 if no error is detected either by this script or by Google Play.')
         else:
             log.warning('APKs will be submitted to Google Play, but no change will not be committed.')
     else:
-        log.warning('You do not have the rights to reach Google Play. *All* requests will be mocked.')
+        log.warning('This pushapk instance is not allowed to talk to Google Play. *All* requests will be mocked.')
 
 
 def get_default_config():

--- a/pushapkscript/test/test_googleplay.py
+++ b/pushapkscript/test/test_googleplay.py
@@ -75,6 +75,14 @@ class GooglePlayTest(unittest.TestCase):
         config = craft_push_apk_config(self.context, self.apks)
         self.assertTrue(config['do_not_contact_google_play'])
 
+    def test_craft_config_instance_config_file_allows_to_contact_google_play_or_not(self):
+        config = craft_push_apk_config(self.context, self.apks)
+        self.assertNotIn('do_not_contact_google_play', config)
+
+        self.context.config['do_not_contact_google_play'] = True
+        config = craft_push_apk_config(self.context, self.apks)
+        self.assertTrue(config['do_not_contact_google_play'])
+
     def test_craft_push_config_allows_committing_apks(self):
         self.context.task['scopes'] = ['project:releng:googleplay:aurora']
         self.context.task['payload']['commit'] = True

--- a/pushapkscript/test/test_googleplay.py
+++ b/pushapkscript/test/test_googleplay.py
@@ -67,11 +67,10 @@ class GooglePlayTest(unittest.TestCase):
         })
 
     def test_craft_push_config_allows_to_contact_google_play_or_not(self):
-        self.context.task['scopes'] = ['project:releng:googleplay:aurora']
         config = craft_push_apk_config(self.context, self.apks)
         self.assertNotIn('do_not_contact_google_play', config)
 
-        self.context.task['scopes'] = ['project:releng:googleplay:dep']
+        self.context.config['do_not_contact_google_play'] = True
         config = craft_push_apk_config(self.context, self.apks)
         self.assertTrue(config['do_not_contact_google_play'])
 


### PR DESCRIPTION
I'm going to deploy a `build-puppet` change with this that adds `do_not_contact_google_play` to each of the dep instances