### PR TITLE
Adds certificate_alias to schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.4] - 2019-05-14
+
+### Fixes
+* `certificate_alias` is now added to the schema
+
+
 ## [1.0.3] - 2019-05-07
+
+### Added
 * New task parameter `certificate_alias`: defines the specific certificate alias that should be used to verify the APK  to upload
 
 ## [1.0.2] - 2019-04-26

--- a/pushapkscript/data/pushapk_task_schema.json
+++ b/pushapkscript/data/pushapk_task_schema.json
@@ -50,6 +50,9 @@
                     "minItems": 1,
                     "uniqueItems": true
                 },
+                "certificate_alias": {
+                  "type": "string"
+                },
                 "google_play_track": {
                   "type": "string"
                 },


### PR DESCRIPTION
I added `certificate_alias` usage to `pushapkscript` without adding it to the schema.
This would've been caught in testing, but my associated product PR got merged before I could test