### PR TITLE
Removes json-parsing from integration tests

### DIFF
--- a/pushapkscript/test/helpers/task_generator.py
+++ b/pushapkscript/test/helpers/task_generator.py
@@ -14,11 +14,15 @@ class TaskGenerator(object):
     def generate_file(self, work_dir):
         task_file = os.path.join(work_dir, 'task.json')
         with open(task_file, 'w') as f:
-            json.dump(self.generate_json(), f)
+            json.dump(self.generate_task(), f)
         return task_file
 
-    def generate_json(self):
-        json_content = json.loads('''{{
+    def generate_task(self):
+        arm_task_id = self.arm_task_id
+        x86_task_id = self.x86_task_id
+        strings_task_id = self.google_play_strings_task_id
+        google_play_track = self.google_play_track
+        task = {
           "provisionerId": "some-provisioner-id",
           "workerType": "some-worker-type",
           "schedulerId": "some-scheduler-id",
@@ -28,36 +32,31 @@ class TaskGenerator(object):
           "created": "2015-05-08T16:15:58.903Z",
           "deadline": "2015-05-08T18:15:59.010Z",
           "expires": "2016-05-08T18:15:59.010Z",
-          "dependencies": ["{arm_task_id}", "{x86_task_id}"],
+          "dependencies": [arm_task_id, x86_task_id],
           "scopes": ["project:releng:googleplay:aurora"],
-          "payload": {{
-            "upstreamArtifacts": [{{
+          "payload": {
+            "upstreamArtifacts": [{
               "paths": ["public/build/target.apk"],
-              "taskId": "{arm_task_id}",
+              "taskId": arm_task_id,
               "taskType": "signing"
-            }}, {{
+            }, {
               "paths": ["public/build/target.apk"],
-              "taskId": "{x86_task_id}",
+              "taskId": x86_task_id,
               "taskType": "signing"
-            }}, {{
+            }, {
               "paths": ["public/google_play_strings.json"],
-              "taskId": "{strings_task_id}",
+              "taskId": strings_task_id,
               "taskType": "build",
-              "optional": true
-            }}],
-            "google_play_track": "{google_play_track}"
-          }}
-        }}'''.format(
-            arm_task_id=self.arm_task_id,
-            x86_task_id=self.x86_task_id,
-            strings_task_id=self.google_play_strings_task_id,
-            google_play_track=self.google_play_track,
-        ))
+              "optional": True
+            }],
+            "google_play_track": google_play_track
+          }
+        }
 
         if self.rollout_percentage:
-            json_content['payload']['rollout_percentage'] = self.rollout_percentage
+            task['payload']['rollout_percentage'] = self.rollout_percentage
 
         if self.should_commit_transaction:
-            json_content['payload']['commit'] = True
+            task['payload']['commit'] = True
 
-        return json_content
+        return task

--- a/pushapkscript/test/integration/test_integration_script.py
+++ b/pushapkscript/test/integration/test_integration_script.py
@@ -43,33 +43,32 @@ class ConfigFileGenerator(object):
 
     def generate(self):
         with open(self.config_file, 'w') as f:
-            json.dump(self._generate_json(), f)
+            json.dump(self._generate_config(), f)
         return self.config_file
 
-    def _generate_json(self):
-        return json.loads('''{{
-            "work_dir": "{work_dir}",
-            "verbose": true,
+    def _generate_config(self):
+        work_dir = self.work_dir
+        keystore_path = self.keystore_manager.keystore_path
+        certificate_alias = self.keystore_manager.certificate_alias
+        return {
+            "work_dir": work_dir,
+            "verbose": True,
 
-            "jarsigner_key_store": "{keystore_path}",
-            "jarsigner_certificate_alias": "{certificate_alias}",
-            "products": {{
-                "aurora": {{
+            "jarsigner_key_store": keystore_path,
+            "jarsigner_certificate_alias": certificate_alias,
+            "products": {
+                "aurora": {
                     "digest_algorithm": "SHA1",
                     "service_account": "dummy-service-account@iam.gserviceaccount.com",
                     "certificate": "/dummy/path/to/certificate.p12",
-                    "has_nightly_track": false,
-                    "skip_check_package_names": false,
-                    "update_google_play_strings": true,
+                    "has_nightly_track": False,
+                    "skip_check_package_names": False,
+                    "update_google_play_strings": True,
                     "expected_package_names": ["org.mozilla.fennec_aurora"]
-                }}
-            }},
+                }
+            },
             "taskcluster_scope_prefixes": ["project:releng:googleplay:"]
-        }}'''.format(
-            work_dir=self.work_dir, test_data_dir=self.test_data_dir,
-            keystore_path=self.keystore_manager.keystore_path,
-            certificate_alias=self.keystore_manager.certificate_alias
-        ))
+        }
 
 
 @unittest.mock.patch('pushapkscript.script.open', new=mock_open)

--- a/pushapkscript/test/test_task.py
+++ b/pushapkscript/test/test_task.py
@@ -20,7 +20,7 @@ def context():
 
 
 def test_validate_task(context):
-    context.task = TaskGenerator().generate_json()
+    context.task = TaskGenerator().generate_task()
     validate_task_schema(context)
 
 


### PR DESCRIPTION
While working on #85, I found updating integration tests more time-consuming than it needed to be.
Do we need JSON-parsing to be part of our integration testing?