### PR TITLE
Adjust trust level

### DIFF
--- a/docker.d/init.sh
+++ b/docker.d/init.sh
@@ -22,7 +22,11 @@ case $ENV in
     export WORKER_SUFFIX=
     ;;
   fake-prod)
-    export TRUST_LEVEL=t
+    export TRUST_LEVEL=1
+    # special case for signing, using -t- instead
+    if [ $PROJECT_NAME = "signing" ]; then
+        export TRUST_LEVEL=t
+    fi
     export WORKER_SUFFIX=
     ;;
   dev)


### PR DESCRIPTION
I misunderstood the initial proposal and the idea is to use `TRUST_LEVEL=t` only fro signing workers, because they are shared among the different pools.